### PR TITLE
chore(dependabot): weekly Saturday 00:01 UTC schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "00:01"
     commit-message:
       prefix: ":books:"
     labels:
@@ -21,6 +23,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "00:01"
     commit-message:
       prefix: ":books:"
     labels:


### PR DESCRIPTION
Sets all Dependabot version-update schedules to run weekly on Saturday at 00:01 UTC.

- `interval: weekly`
- `day: saturday`
- `time: "00:01"` (UTC, Dependabot default timezone)

(Reopened as a fresh PR: the original was auto-closed by GitHub after a force-push during commit signing.)